### PR TITLE
Use link tokens instead of public key for linking/relinking accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ plaid-cli will look at the following environment variables for API credentials:
 PLAID_CLIENT_ID=<client id>
 PLAID_SECRET=<devlopment secret>
 PLAID_ENVIRONMENT=development
+PLAID_LANGUAGE=en  # optional, detected using system's locale
+PLAID_COUNTRIES=US # optional, detected using system's locale
 ```
 
 I recommend setting and exporting these on shell startup.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ plaid-cli will look at the following environment variables for API credentials:
 
 ```sh
 PLAID_CLIENT_ID=<client id>
-PLAID_PUBLIC_KEY=<public key>
 PLAID_SECRET=<devlopment secret>
 PLAID_ENVIRONMENT=development
 ```
@@ -39,7 +38,6 @@ API credentials can also be specified using a config file located at
 ```toml
 [plaid]
 client_id = "<client id>"
-public_key = "<public key>"
 secret = "<development secret>"
 environment = "development"
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/landakram/plaid-cli
 go 1.14
 
 require (
+	github.com/Xuanwo/go-locale v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
@@ -16,6 +17,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1 // indirect
-	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
+	golang.org/x/text v0.3.3
 	gopkg.in/ini.v1 v1.57.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
-	github.com/plaid/plaid-go v0.0.0-20200529200923-9627743aa512
+	github.com/plaid/plaid-go v0.0.0-20210112002311-0cf0e6f0ea3e
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Xuanwo/go-locale v1.0.0 h1:oqC32Kyiu2XZq+fxtwEg0mWiv9WyDhyHu+sT5cDkgME=
+github.com/Xuanwo/go-locale v1.0.0/go.mod h1:kB9tcLfr4Sp+ByIE9SE7vbUkXkGQqel2XH3EHpL0haA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -107,6 +109,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
@@ -180,7 +183,9 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -287,10 +292,14 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3 h1:qDJKu1y/1SjhWac4BQZjLljqvqiWUhjmDMnonmVGDAU=
+golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/plaid/plaid-go v0.0.0-20200529200923-9627743aa512 h1:XmKvXLOGi20FfHv20HQYhct0y4vLOcSaT+cMz4MIDw0=
 github.com/plaid/plaid-go v0.0.0-20200529200923-9627743aa512/go.mod h1:c7cDT1Lkcr0AgKJGVIG+oCa07jOrrg4Um8nduQ1eQN0=
+github.com/plaid/plaid-go v0.0.0-20210112002311-0cf0e6f0ea3e h1:8uVgUfPCS63Ys/8BawzsnDZem8NQsCUlo2yKO0uSqac=
+github.com/plaid/plaid-go v0.0.0-20210112002311-0cf0e6f0ea3e/go.mod h1:c7cDT1Lkcr0AgKJGVIG+oCa07jOrrg4Um8nduQ1eQN0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/pkg/plaid_cli/linker.go
+++ b/pkg/plaid_cli/linker.go
@@ -149,7 +149,7 @@ func handleLink(linker *Linker, linkToken string) func(w http.ResponseWriter, r 
 			t, _ = t.Parse(linkTemplate)
 
 			d := LinkTmplData{
-				LinkToken:   linkToken,
+				LinkToken: linkToken,
 			}
 			t.Execute(w, d)
 		case http.MethodPost:
@@ -169,11 +169,11 @@ func handleLink(linker *Linker, linkToken string) func(w http.ResponseWriter, r 
 }
 
 type LinkTmplData struct {
-	LinkToken   string
+	LinkToken string
 }
 
 type RelinkTmplData struct {
-	LinkToken   string
+	LinkToken string
 }
 
 func handleRelink(linker *Linker, linkToken string) func(w http.ResponseWriter, r *http.Request) {
@@ -184,7 +184,7 @@ func handleRelink(linker *Linker, linkToken string) func(w http.ResponseWriter, 
 			t, _ = t.Parse(relinkTemplate)
 
 			d := RelinkTmplData{
-				LinkToken:   linkToken,
+				LinkToken: linkToken,
 			}
 			t.Execute(w, d)
 		case http.MethodPost:
@@ -207,19 +207,19 @@ var linkTemplate string = `<html>
   <head>
     <style>
     .alert-success {
-        font-size: 1.2em;
-        font-family: Arial, Helvetica, sans-serif;
-        background-color: #008000;
-        color: #fff;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        border-radius: 15px;
-        width: 100%;
-        height: 100%;
+	font-size: 1.2em;
+	font-family: Arial, Helvetica, sans-serif;
+	background-color: #008000;
+	color: #fff;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	border-radius: 15px;
+	width: 100%;
+	height: 100%;
     }
     .hidden {
-        visibility: hidden;
+	visibility: hidden;
     }
     </style>
   </head>
@@ -229,28 +229,28 @@ var linkTemplate string = `<html>
     <script type="text/javascript">
      (function($) {
        var handler = Plaid.create({
-         token: '{{ .LinkToken }}',
-         onSuccess: function(public_token, metadata) {
+	 token: '{{ .LinkToken }}',
+	 onSuccess: function(public_token, metadata) {
 	   // Send the public_token to your app server.
-           // The metadata object contains info about the institution the
-           // user selected and the account ID or IDs, if the
-           // Select Account view is enabled.
-           $.post('/link', {
-             public_token: public_token,
-           });
-           document.getElementById("alert").classList.remove("hidden");
-         },
-         onExit: function(err, metadata) {
-           // The user exited the Link flow.
-           if (err != null) {
-             // The user encountered a Plaid API error prior to exiting.
-           }
-           // metadata contains information about the institution
-           // that the user selected and the most recent API request IDs.
-           // Storing this information can be helpful for support.
+	   // The metadata object contains info about the institution the
+	   // user selected and the account ID or IDs, if the
+	   // Select Account view is enabled.
+	   $.post('/link', {
+	     public_token: public_token,
+	   });
+	   document.getElementById("alert").classList.remove("hidden");
+	 },
+	 onExit: function(err, metadata) {
+	   // The user exited the Link flow.
+	   if (err != null) {
+	     // The user encountered a Plaid API error prior to exiting.
+	   }
+	   // metadata contains information about the institution
+	   // that the user selected and the most recent API request IDs.
+	   // Storing this information can be helpful for support.
 
-           document.getElementById("alert").classList.remove("hidden");
-         }
+	   document.getElementById("alert").classList.remove("hidden");
+	 }
        });
 
        handler.open();
@@ -260,8 +260,8 @@ var linkTemplate string = `<html>
 
     <div id="alert" class="alert-success hidden">
       <div>
-        <h2>All done here!</h2>
-        <p>You can close this window and go back to plaid-cli.</p>
+	<h2>All done here!</h2>
+	<p>You can close this window and go back to plaid-cli.</p>
       </div>
     </div>
   </body>
@@ -271,19 +271,19 @@ var relinkTemplate string = `<html>
   <head>
     <style>
     .alert-success {
-        font-size: 1.2em;
-        font-family: Arial, Helvetica, sans-serif;
-        background-color: #008000;
-        color: #fff;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        border-radius: 15px;
-        width: 100%;
-        height: 100%;
+	font-size: 1.2em;
+	font-family: Arial, Helvetica, sans-serif;
+	background-color: #008000;
+	color: #fff;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	border-radius: 15px;
+	width: 100%;
+	height: 100%;
     }
     .hidden {
-        visibility: hidden;
+	visibility: hidden;
     }
     </style>
   </head>
@@ -293,28 +293,28 @@ var relinkTemplate string = `<html>
     <script type="text/javascript">
      (function($) {
        var handler = Plaid.create({
-         token: '{{ .LinkToken }}',
-         onSuccess: (public_token, metadata) => {
-           // You do not need to repeat the /item/public_token/exchange
-           // process when a user uses Link in update mode.
-           // The Item's access_token has not changed.
-         },
-         onExit: function(err, metadata) {
-           if (err != null) {
-             $.post('/relink', {
-               error: err
-             });
-           } else {
-             $.post('/relink', {
-               error: null
-             });
-           }
-           // metadata contains information about the institution
-           // that the user selected and the most recent API request IDs.
-           // Storing this information can be helpful for support.
+	 token: '{{ .LinkToken }}',
+	 onSuccess: (public_token, metadata) => {
+	   // You do not need to repeat the /item/public_token/exchange
+	   // process when a user uses Link in update mode.
+	   // The Item's access_token has not changed.
+	 },
+	 onExit: function(err, metadata) {
+	   if (err != null) {
+	     $.post('/relink', {
+	       error: err
+	     });
+	   } else {
+	     $.post('/relink', {
+	       error: null
+	     });
+	   }
+	   // metadata contains information about the institution
+	   // that the user selected and the most recent API request IDs.
+	   // Storing this information can be helpful for support.
 
-           document.getElementById("alert").classList.remove("hidden");
-         }
+	   document.getElementById("alert").classList.remove("hidden");
+	 }
        });
 
        handler.open();
@@ -324,8 +324,8 @@ var relinkTemplate string = `<html>
 
     <div id="alert" class="alert-success hidden">
       <div>
-        <h2>All done here!</h2>
-        <p>You can close this window and go back to plaid-cli.</p>
+	<h2>All done here!</h2>
+	<p>You can close this window and go back to plaid-cli.</p>
       </div>
     </div>
   </body>


### PR DESCRIPTION
This is an attempt at resolving #1  - using link tokens instead of public keys to access the Plaid API. I basically followed the template you suggested - updating the `plaid-go` dependency to the latest version and changing the link and relink flows to use the new link token methods. I don't have much Go experience, so any feedback is welcome.

I had to break out a totally separate `relink` method in the linker, since in the new flow relinking doesn't return anything on success - the access token the app previously had just stays valid. This made the linker more verbose than it was before, but I couldn't think of a better way to represent the new logic.

Let me know what you think!